### PR TITLE
Added synthetic train_metrics.csv for the report

### DIFF
--- a/results/train_metrics.csv
+++ b/results/train_metrics.csv
@@ -1,0 +1,7 @@
+Model,Train R^2,Test R^2
+Linear Regression,0.555803,0.526354
+Stochastic Gradient Descent,0.550439,0.528612
+kNN,0.638008,0.626848
+Random Forests,0.964447,0.734342
+Gradient Boosted Trees,0.803595,0.736818
+Support Vector Machines,0.840271,0.813724


### PR DESCRIPTION
Braden, take a look - should be just right for the report. Soon it will be generated by train_model.py, but in the meanwhile you can use the synthetic version